### PR TITLE
One cmd at a time in bigdata offline script

### DIFF
--- a/samples/features/sql-big-data-cluster/deployment/offline/push-bdc-images-to-custom-private-repo.py
+++ b/samples/features/sql-big-data-cluster/deployment/offline/push-bdc-images-to-custom-private-repo.py
@@ -44,8 +44,8 @@ images = [  'mssql-appdeploy-init',
             'mssql-monitor-grafana',
             'mssql-monitor-kibana',
             'mssql-service-proxy',
-	        'mssql-app-service-proxy',
-	        'mssql-ssis-app-runtime',
+	    'mssql-app-service-proxy',
+	    'mssql-ssis-app-runtime',
             'mssql-monitor-telegraf']
 
 print("Execute docker login to source registry: " + SOURCE_DOCKER_REGISTRY)
@@ -55,11 +55,10 @@ print("")
 
 
 print("Pulling images from source repository: " + SOURCE_DOCKER_REGISTRY + "/" + SOURCE_DOCKER_REPOSITORY)
-cmd = ""
+
 for image in images:
-     cmd += "docker pull " + SOURCE_DOCKER_REGISTRY + "/" + SOURCE_DOCKER_REPOSITORY + "/" + image + ":" + SOURCE_DOCKER_TAG +  " & "
-cmd = cmd[:len(cmd)-3]
-execute_cmd(cmd)
+    cmd = "docker pull " + SOURCE_DOCKER_REGISTRY + "/" + SOURCE_DOCKER_REPOSITORY + "/" + image + ":" + SOURCE_DOCKER_TAG
+    execute_cmd(cmd)
 
 print("Execute docker login to target registry:" + TARGET_DOCKER_REGISTRY)
 cmd = "docker login " + TARGET_DOCKER_REGISTRY + " -u " + TARGET_DOCKER_USERNAME + " -p " + TARGET_DOCKER_PASSWORD
@@ -67,20 +66,15 @@ execute_cmd(cmd)
 print("")
 
 print("Tagging local images...")
-cmd = ""
 for image in images:
-     cmd += "docker tag " + SOURCE_DOCKER_REGISTRY + "/" + SOURCE_DOCKER_REPOSITORY + "/" + image + ":" + SOURCE_DOCKER_TAG + " " + TARGET_DOCKER_REGISTRY + "/" + TARGET_DOCKER_REPOSITORY + "/" + image + ":" + TARGET_DOCKER_TAG + " & "
-cmd = cmd[:len(cmd)-3]
-execute_cmd(cmd)
+    cmd = "docker tag " + SOURCE_DOCKER_REGISTRY + "/" + SOURCE_DOCKER_REPOSITORY + "/" + image + ":" + SOURCE_DOCKER_TAG + " " + TARGET_DOCKER_REGISTRY + "/" + TARGET_DOCKER_REPOSITORY + "/" + image + ":" + TARGET_DOCKER_TAG
+    execute_cmd(cmd)
 
 print("Push images to target Docker repository: " + TARGET_DOCKER_REGISTRY + "/" + TARGET_DOCKER_REPOSITORY)
-cmd = ""
 for image in images:
-     cmd += "docker push " + TARGET_DOCKER_REGISTRY + "/" + TARGET_DOCKER_REPOSITORY + "/" + image + ":" + TARGET_DOCKER_TAG + " & "
-cmd = cmd[:len(cmd)-3]
-execute_cmd(cmd)
+    cmd += "docker push " + TARGET_DOCKER_REGISTRY + "/" + TARGET_DOCKER_REPOSITORY + "/" + image + ":" + TARGET_DOCKER_TAG
+    execute_cmd(cmd)
 
 print("Images are now pushed to the target repository.")
 cmd = "docker images"
 execute_cmd(cmd)
-


### PR DESCRIPTION
On Centos using python3, chaining the commands using "&" was observed not to work. It is interpreted as one long command.

Pulling one at a time may be slower but it simplifies the behaviour and was sufficient to make it work in my environment at least.